### PR TITLE
Fixes to installer

### DIFF
--- a/build-windows.md
+++ b/build-windows.md
@@ -28,7 +28,7 @@
 
 
 ## package setup.exe
--  Download 32 bit version of these libs [VSC++2015 SP3](https://www.microsoft.com/en-us/download/details.aspx?id=53840), [VSC++2010Sp1](https://www.microsoft.com/en-us/download/details.aspx?id=26999) and put in folder `pxCore\pxCore.vsbuild\pxScene2d`.
+-  Download 32 bit version of [VSC++2017](https://go.microsoft.com/fwlink/?LinkId=746571), and put in folder `pxCore\pxCore.vsbuild\pxScene2d`.
 -  use inno setup Compiler open `pxCore\pxCore.vsbuild\pxScene2d\make_package.iss`
 -  modify `Files` section,  `Source` to your exe path.
 -  use `build->Compile` , after that , you can find `setup.exe` at `pxCore\pxCore.vsbuild\pxScene2d\Output` ,you can double click to install pxscene

--- a/pxCore.vsbuild/pxScene2d/make_package.iss
+++ b/pxCore.vsbuild/pxScene2d/make_package.iss
@@ -14,7 +14,7 @@ AppSupportURL=http://www.example.com/
 AppUpdatesURL=http://www.example.com/
 DefaultDirName={pf}\pxScene
 DisableProgramGroupPage=yes
-OutputBaseFilename=setup
+OutputBaseFilename=pxSetup
 Compression=lzma
 SolidCompression=yes  
 
@@ -25,20 +25,16 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-; Visual C++ 2010 SP1 Redist(x86) installer
-Source: "C:\wk\pxCore\pxCore.vsbuild\pxScene2d\vcredist_x86.exe"; DestDir: {tmp}; Flags: deleteafterinstall
 ; Visual C++ 2015 SP3 Redist(x86)installer
-Source: "C:\wk\pxCore\pxCore.vsbuild\pxScene2d\vc_redist.x86.exe"; DestDir: {tmp}; Flags: deleteafterinstall
-Source: "C:\wk\pxCore\pxCore.vsbuild\pxScene2d\exe\pxScene.exe"; DestDir: "{app}"; Flags: ignoreversion;
-Source: "C:\wk\pxCore\pxCore.vsbuild\pxScene2d\exe\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "vc_redist.x86.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall
+Source: "exe\pxScene.exe"; DestDir: "{app}"; Flags: ignoreversion;
+Source: "exe\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Run]
 ; the conditional installation Check
-; install  Visual C++ 2010 SP1 Redist(x86) if not exist
-Filename: "{tmp}\vcredist_x86.exe"; Parameters: "/q /norestart"; StatusMsg: "Installing Microsoft Visual C++ 2010 SP1 Runtime ..."; Check: VC2010SP1RedistNeedsInstall
-; install  Visual C++ 2015 SP3 Redist(x86) if not exist
-Filename: "{tmp}\vc_redist.x86.exe"; Parameters: "/q /norestart"; StatusMsg: "Installing Microsoft Visual C++ 2015 SP3 Runtime ..."; Check: VC2015SP3RedistNeedsInstall
+; install  Visual C++ 2017 Redist(x86) if not exist
+Filename: "{tmp}\vc_redist.x86.exe"; Parameters: "/q /norestart"; StatusMsg: "Installing Microsoft Visual C++ 2017 Runtime ..."; Check: VC2017RedistNeedsInstall
 
 [Code]
 #IFDEF UNICODE
@@ -55,11 +51,8 @@ const
   INSTALLSTATE_ABSENT = 2;       { The product is installed for a different user. }
   INSTALLSTATE_DEFAULT = 5;      { The product is installed for the current user. }
 
-  {Visual C++ 2010 SP1 Redist(x86) 10.0.40219} 
-  VC_2010_SP1_REDIST_X86 = '{F0C3E5D1-1ADE-321E-8167-68EF0DE699A5}';
- 
-  {Visual C++ 2015 SP3 Redist(x86) 14.0.24215}
-  VC_2015_SP3_REDIST_X86 = '{BBF2AC74-720C-3CB3-8291-5E34039232FA}';
+  {Visual C++ 2017 Redist(x86) 14.10.25017}
+  VC_2017_REDIST_X86 = '{582EA838-9199-3518-A05C-DB09462F68EC}';
 
 function MsiQueryProductState(szProduct: string): INSTALLSTATE; 
   external 'MsiQueryProductState{#AW}@msi.dll stdcall';
@@ -69,14 +62,9 @@ begin
   Result := not (MsiQueryProductState(ProductID) = INSTALLSTATE_DEFAULT);
 end;
 
-function VC2010SP1RedistNeedsInstall: Boolean;
+function VC2017RedistNeedsInstall: Boolean;
 begin
-  Result := VCVersionInstalled(VC_2010_SP1_REDIST_X86);
-end;
-
-function VC2015SP3RedistNeedsInstall: Boolean;
-begin
-  Result := VCVersionInstalled(VC_2015_SP3_REDIST_X86);
+  Result := VCVersionInstalled(VC_2017_REDIST_X86);
 end;
 
 function NextButtonClick(CurPageID: Integer): Boolean;


### PR DESCRIPTION
  - Removed dependency to VC++ 2010 Redist
  - Changed dependency from VC++ 2015 to VC++2017 Redist
  - Paths are relatives, no need to change when creating the installer
  - Updated doc accordingly.

Attaching a installer with the latest code.
[pxSetup.zip](https://github.com/topcoderinc/pxCore/files/959899/pxSetup.zip)

