### PR TITLE
Fix for failing linux build in CI. Issue #51

### DIFF
--- a/examples/pxScene2d/src/pxScene.cpp
+++ b/examples/pxScene2d/src/pxScene.cpp
@@ -195,27 +195,12 @@ protected:
 #endif 
    // pxScene.cpp:104:12: warning: deleting object of abstract class type ‘pxIView’ which has non-virtual destructor will cause undefined behaviour [-Wdelete-non-virtual-dtor]
 
-#ifdef RUNINMAIN
-   script.garbageCollect();
-#endif
 ENTERSCENELOCK()
     mView = NULL;
 EXITSCENELOCK()
 #ifndef RUNINMAIN
    script.setNeedsToEnd(true);
 #endif
-  #ifdef ENABLE_DEBUG_MODE
-    free(g_origArgv);
-  #endif
-    script.garbageCollect();
-    if (gDumpMemUsage)
-    {
-      rtLogInfo("pxobjectcount is [%d]",pxObjectCount);
-      rtLogInfo("texture memory usage is [%ld]",context.currentTextureMemoryUsageInBytes());
-    }
-    #ifdef ENABLE_CODE_COVERAGE
-    __gcov_flush();
-    #endif
   ENTERSCENELOCK()
       eventLoop.exit();
   EXITSCENELOCK()
@@ -498,6 +483,7 @@ if (s && (strcmp(s,"1") == 0))
 #endif
 
   eventLoop.run();
+
 #ifdef ENABLE_DEBUG_MODE
   free(g_origArgv);
 #endif
@@ -507,6 +493,10 @@ if (s && (strcmp(s,"1") == 0))
     rtLogInfo("pxobjectcount is [%d]",pxObjectCount);
     rtLogInfo("texture memory usage is [%ld]",context.currentTextureMemoryUsageInBytes());
   }
+#ifdef ENABLE_CODE_COVERAGE
+    __gcov_flush();
+#endif
+
 
 
 #ifdef WIN32

--- a/src/glut/pxWindowNative.cpp
+++ b/src/glut/pxWindowNative.cpp
@@ -560,7 +560,7 @@ bool exitFlag = false;
 
 pxWindowNative::~pxWindowNative()
 {
-  cleanupGlutWindow();
+  
 }
 
 void pxWindowNative::createGlutWindow(int left, int top, int width, int height)
@@ -583,7 +583,7 @@ void pxWindowNative::createGlutWindow(int left, int top, int width, int height)
 
 void pxWindowNative::cleanupGlutWindow()
 {
-  glutDestroyWindow(mGlutWindowId);
+  // NOOP
 }
 
 pxError pxWindow::init(int left, int top, int width, int height)
@@ -642,7 +642,6 @@ pxError pxWindow::init(int left, int top, int width, int height)
 
 pxError pxWindow::term()
 {
-  cleanupGlutWindow();
   return PX_OK;
 }
 


### PR DESCRIPTION
On shutdown the code called glutDestroyWindow method. This is unecessary
since freeglut destroy all context before returning from eventloop. This
was likely added because the original windows port code used an old version
of GLUT.

Also fixed duplicate node cleanup and memory diagnostics code that were being called twice.

Note: tested the CI scripts locally and it passed. Let's see how GH CI fares...