### PR TITLE
Moved cleanup code back to onCloseRequest.

### DIFF
--- a/examples/pxScene2d/src/pxScene.cpp
+++ b/examples/pxScene2d/src/pxScene.cpp
@@ -199,8 +199,22 @@ ENTERSCENELOCK()
     mView = NULL;
 EXITSCENELOCK()
 #ifndef RUNINMAIN
-   script.setNeedsToEnd(true);
+    script.setNeedsToEnd(true);
 #endif
+
+#ifdef ENABLE_DEBUG_MODE
+    free(g_origArgv);
+#endif
+    script.garbageCollect();
+    if (gDumpMemUsage)
+    {
+      rtLogInfo("pxobjectcount is [%d]",pxObjectCount);
+      rtLogInfo("texture memory usage is [%ld]",context.currentTextureMemoryUsageInBytes());
+    }
+#ifdef ENABLE_CODE_COVERAGE
+    __gcov_flush();
+#endif
+
   ENTERSCENELOCK()
       eventLoop.exit();
   EXITSCENELOCK()
@@ -483,20 +497,6 @@ if (s && (strcmp(s,"1") == 0))
 #endif
 
   eventLoop.run();
-
-#ifdef ENABLE_DEBUG_MODE
-  free(g_origArgv);
-#endif
-  script.garbageCollect();
-  if (gDumpMemUsage)
-  {
-    rtLogInfo("pxobjectcount is [%d]",pxObjectCount);
-    rtLogInfo("texture memory usage is [%ld]",context.currentTextureMemoryUsageInBytes());
-  }
-#ifdef ENABLE_CODE_COVERAGE
-    __gcov_flush();
-#endif
-
 
 
 #ifdef WIN32


### PR DESCRIPTION
This also fixes macOS CI builds.

Client commenter was right that the cleanup could should be placed in onCloseRequest method. The issue in macOS was that, on the previous attempt, seemingly the application was dying before writing the output buffer to stdout. Strangely, it worked on Linux though. 