### PR TITLE
#106 build for mac step 1: make it compilable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,4 +169,8 @@ examples/pxScene2d/src/Makefile
 
 tests/pxScene2d/Makefile
 
-
+.vscode/
+remote/mac/
+rtRemoteExample/librtRemote_s.a
+rtRemoteExample/sample_client
+rtRemoteExample/sample_server

--- a/remote/Makefile
+++ b/remote/Makefile
@@ -78,7 +78,23 @@ endif
 CFLAGS+=-DRAPIDJSON_HAS_STDSTRING -Werror -Wall -Wextra -DRT_PLATFORM_LINUX -I../src -I. -fPIC -Wno-deprecated-declarations
 CFLAGS+=-DRT_REMOTE_LOOPBACK_ONLY
 CXXFLAGS+=-std=c++0x $(CFLAGS)
-LDFLAGS =-pthread -ldl $(LIBUUID) -Wl,-rpath=../../,--enable-new-dtags
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	LDFLAGS =-L../../ -ldl $(LIBUUID) -Wl,-rpath -Xlinker ../../,--enable-new-dtags
+else
+	LDFLAGS =-pthread -ldl $(LIBUUID) -Wl,-rpath=../../,--enable-new-dtags
+endif
+
+EXTRA_LDFLAGS =-L../build/glut -L../build/egl
+
+# For macOS, ar -o is not supported.
+ifeq ($(UNAME_S),Darwin)
+  AR_OUT_FLAG =
+else
+  AR_OUT_FLAG =-o
+endif
+
 OBJDIR=obj
 
 RTCORE_OBJS =$(patsubst ../%.cpp, %.o        , $(notdir $(RTCORE_SRCS)))
@@ -140,21 +156,21 @@ perftest:
 	$(MAKE) -C tests perftest
 
 librtRemote.so: $(RTRPC_OBJS)
-	$(CXX_PRETTY) $(RTRPC_OBJS) $(LDFLAGS) -shared -o $@
+	$(CXX_PRETTY) $(RTRPC_OBJS) $(LDFLAGS) -lrtCore -shared -o $@
 
 librtRemote_s.a: $(RTRPC_OBJS)
-	$(AR) rcs -o $@ $(RTRPC_OBJS)
+	$(AR) rcs $(AR_OUT_FLAG) $@ $(RTRPC_OBJS)
 
 rpcSampleApp: $(SAMPLEAPP_OBJS) librtRemote.so
-	$(CXX_PRETTY) $(SAMPLEAPP_OBJS) $(LDFLAGS) -o $@ -L./ -L../build/glut -L../build/egl -lrtCore -lrtRemote $(LIBUUID)
+	$(CXX_PRETTY) $(SAMPLEAPP_OBJS) $(LDFLAGS) -o $@ -L./ $(EXTRA_LDFLAGS) -lrtCore -lrtRemote $(LIBUUID)
 
 rpcSampleApp_s: $(SAMPLEAPP_OBJS) librtRemote_s.a
-	$(CXX_PRETTY) $(SAMPLEAPP_OBJS) $(LDFLAGS) -o $@ -L./ -L../build/glut -L../build/egl -lrtCore_s -lrtRemote_s $(LIBUUID)
+	$(CXX_PRETTY) $(SAMPLEAPP_OBJS) $(LDFLAGS) -o $@ -L./ $(EXTRA_LDFLAGS) -lrtCore_s -lrtRemote_s $(LIBUUID)
 
 rpcSampleSimple: librtRemote.so
 	$(CXX_PRETTY) rtSampleClient.cpp -DRT_PLATFORM_LINUX -I. -DRAPIDJSON_HAS_STDSTRING\
-    -o rtSampleClient -I../src -L. -L../build/egl -lrtCore -lrtRemote $(LIBUUID) -std=c++11 -pthread
+    -o rtSampleClient -I../src -L. $(EXTRA_LDFLAGS) -lrtCore -lrtRemote $(LIBUUID) -std=c++11 -pthread
 	$(CXX_PRETTY) rtSampleServer.cpp -DRT_PLATFORM_LINUX -I. -DRAPIDJSON_HAS_STDSTRING\
-    -o rtSampleServer -I../src -L. -L../build/egl -lrtCore -lrtRemote $(LIBUUID) -std=c++11 -pthread
+    -o rtSampleServer -I../src -L. $(EXTRA_LDFLAGS) -lrtCore -lrtRemote $(LIBUUID) -std=c++11 -pthread
 
 .PHONY: all debug clean

--- a/remote/polyfill.h
+++ b/remote/polyfill.h
@@ -1,0 +1,20 @@
+#ifndef POLYFILL_H_
+#define POLYFILL_H_
+
+// A poly fill headers for mac os
+// SOL_TCP is not defined on mac
+#ifndef SOL_TCP
+#define SOL_TCP IPPROTO_TCP
+#endif
+
+#if defined(__APPLE__)
+
+// No pipe2 on mac, use pipe instead
+// Not found an equivalent workaround for flags O_CLOEXEC
+// So in mac, O_CLOEXEC will be ignored.
+#define pipe2(pipefd, flags) \
+	pipe(pipefd)
+
+#endif
+
+#endif

--- a/remote/rtRemoteConfigGen.cpp
+++ b/remote/rtRemoteConfigGen.cpp
@@ -165,7 +165,12 @@ static std::set<ConfigItem> buildConfigItems(rapidjson::Value const& configParam
       configItems.insert(item);
     }
   });
+#if __clang__
+  // For clang, remove std::move because of forbiding copy elision
+  return configItems;
+#else
   return std::move(configItems);
+#endif
 }
 
 

--- a/remote/rtRemoteMulticastResolver.h
+++ b/remote/rtRemoteMulticastResolver.h
@@ -9,6 +9,8 @@
 #include <netinet/in.h>
 #include <rtObject.h>
 
+#include "polyfill.h"
+
 #include "rtRemoteCorrelationKey.h"
 #include "rtRemoteTypes.h"
 #include "rtRemoteSocketUtils.h"

--- a/remote/rtRemoteNameService.cpp
+++ b/remote/rtRemoteNameService.cpp
@@ -4,6 +4,8 @@
 #include "rtRemoteConfig.h"
 #include "rtRemoteEnvironment.h"
 
+#include "polyfill.h"
+
 #include <condition_variable>
 #include <thread>
 #include <mutex>

--- a/remote/rtRemoteNsResolver.cpp
+++ b/remote/rtRemoteNsResolver.cpp
@@ -4,6 +4,8 @@
 #include "rtRemoteConfig.h"
 #include "rtRemoteEnvironment.h"
 
+#include "polyfill.h"
+
 #include <condition_variable>
 #include <thread>
 #include <mutex>

--- a/remote/rtRemoteServer.cpp
+++ b/remote/rtRemoteServer.cpp
@@ -12,6 +12,8 @@
 #include "rtRemoteConfig.h"
 #include "rtRemoteFactory.h"
 
+#include "polyfill.h"
+
 #include <limits>
 #include <sstream>
 #include <set>

--- a/remote/rtRemoteStream.cpp
+++ b/remote/rtRemoteStream.cpp
@@ -4,6 +4,8 @@
 #include "rtRemoteEnvironment.h"
 #include "rtRemoteStreamSelector.h"
 
+#include "polyfill.h"
+
 #include <algorithm>
 #include <memory>
 #include <thread>

--- a/remote/rtRemoteStreamSelector.cpp
+++ b/remote/rtRemoteStreamSelector.cpp
@@ -5,6 +5,8 @@
 #include "rtError.h"
 #include "rtLog.h"
 
+#include "polyfill.h"
+
 #include <algorithm>
 #include <chrono>
 #include <unistd.h>


### PR DESCRIPTION
Now it's compilable on mac. But there are still remaining issues that need further investigation:

1. No /proc on macOS, so it will yield the following warning
```
rt: WARN rtRemoteServer.cpp:72 -- Thread-759304: failed to open directory /proc.
```
which means it will fail to clean up stale unit sockets (See `cleanupStaleUnixSockets()` in rtRemoteServer.cpp).

macOS uses a completely different way to implement the "process" file system, so this part should be re-implement on macOS.

2. If we run `./sample_server` first, then run `./sample_client`, the `./sample_client` will failed to bind the address
```
rt:ERROR rtRemoteMulticastResolver.cpp:267 -- Thread-759304: failed to bind multicast socket to inet:127.0.0.1:10004.
```
Because `./sample_server` already used this address.

So it's weird, I looked through the code, the `client.cpp` and `server.cpp` initialize the socket via the different remote environment, but I'm not sure how to set the environment for client/server differently. I will investigate it further.