### PR TITLE
	rtRemote port cleanup

### DIFF
--- a/remote/CMakeLists.txt
+++ b/remote/CMakeLists.txt
@@ -81,10 +81,9 @@ if (ENABLE_RTREMOTE_DEBUG)
     message("Enabling rtRemote debug")
     add_definitions(-DRT_RPC_DEBUG -DRT_DEBUG)
 
-    if (WIN32)
-    else (WIN32)
+    if (NOT WIN32)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 -fno-inline")
-    endif (WIN32)
+    endif (NOT WIN32)
 
 else()
 
@@ -147,6 +146,7 @@ if (BUILD_RTREMOTE_SAMPLE_APP_SIMPLE)
     link_directories(${RTREMOTE_LINK_DIRECTORIES})
 
     #client
+    message("Building rtremote_sample_app_client")
     add_executable(rtremote_sample_app_client rtSampleClient.cpp)
     set_target_properties(rtremote_sample_app_client PROPERTIES OUTPUT_NAME "rtSampleClient")
 
@@ -163,6 +163,7 @@ endif ()
 
 
     #server
+    message("Building rtremote_sample_app_server")
     add_executable(rtremote_sample_app_server rtSampleServer.cpp)
     set_target_properties(rtremote_sample_app_server PROPERTIES OUTPUT_NAME "rtSampleServer")
 

--- a/remote/rtGuid.cpp
+++ b/remote/rtGuid.cpp
@@ -80,7 +80,8 @@ rtGuid::newRandom()
   {
     buff[j++] = hex2str[((unsigned char)guidObj.Data4[i] & 0xF0) >> 4];
     buff[j++] = hex2str[((unsigned char)guidObj.Data4[i] & 0x0F)];
-    if (i == 3 || i == 5 || i == 7 || i == 9)
+    bool isHyphenNeeded = i == 3 || i == 5 || i == 7 || i == 9;
+    if (isHyphenNeeded)
     {
       buff[j++] = '-';
     }

--- a/remote/rtRemote.cpp
+++ b/remote/rtRemote.cpp
@@ -26,6 +26,8 @@ rtRemoteInit(rtRemoteEnvironment* env)
   rtError e = RT_FAIL;
   std::lock_guard<std::mutex> lock(gMutex);
 
+  // on win32 returns RT_FAIL,
+  // if sockets subsystem failed to start
   e = rtRemoteSocketInit();
   if (e != RT_OK)
   {

--- a/remote/rtRemoteFileResolver.cpp
+++ b/remote/rtRemoteFileResolver.cpp
@@ -1,5 +1,3 @@
-#ifndef RT_PLATFORM_WINDOWS
-
 #include "rtRemoteFileResolver.h"
 #include "rtRemoteSocketUtils.h"
 #include "rtRemoteMessage.h"
@@ -10,9 +8,7 @@
 #include <thread>
 #include <mutex>
 
-#ifndef RT_PLATFORM_WINDOWS
 #include <sys/file.h>
-#endif
 
 #include <rtLog.h>
 
@@ -190,5 +186,3 @@ rtRemoteFileResolver::unregisterObject(std::string const& /*name*/)
 {
   return RT_ERROR_NOT_IMPLEMENTED;
 }
-
-#endif

--- a/step-by-step-duktape-linux-buil(rtRemote).md
+++ b/step-by-step-duktape-linux-buil(rtRemote).md
@@ -39,6 +39,9 @@
 * `./configure`
 * `make all`
 
+#### quilt [macosx]
+* instructions are here: http://macappstore.org/quilt/
+
 #### libjpeg-turbo
 * `cd ..`
 * `cd libjpeg-turbo`


### PR DESCRIPTION
from https://github.com/topcoderinc/pxCore/issues/125
1) pipes in rtRemote are used for shutdown notification only,
 it does not really matter if shutdown will happen after 
 some (select timeout, hundred ms) delay, this solution by setting
 shutdown variable is portable, the only downside is 
 more frequent select wake up, but I think this is not a big issue
 and such shutdown mechanism is used in production code.
 
from https://github.com/topcoderinc/pxCore/issues/127
I think in rtRemoteEndpointHandle.h comments are unnecessary
It is known that on win32 sockets are not ints, so need a way to
abstact socket descriptors with typedef. In code I've ever read 
there were not comments covering this)

in rtRemoteSocketUtils comments are unnecessary too
no portable way to get network adapters, and it is wide known
