### PR TITLE
#163 Avoid data race between handle.waitUntil() and rtRemoteRunUntil()

### DIFF
--- a/remote/rtRemoteAsyncHandle.cpp
+++ b/remote/rtRemoteAsyncHandle.cpp
@@ -64,7 +64,7 @@ rtRemoteAsyncHandle::waitUntil(uint32_t timeoutInMilliseconds, std::function<rtE
       rtLogDebug("Waiting for item with key = %s", m_key.toString().c_str());
 
       m_error = RT_ERROR_TIMEOUT;
-      e = m_env->processSingleWorkItem(waitDuration, true, &k);
+      e = m_env->processSingleWorkItem(waitDuration, true, &k, &m_key);
 
       if ( e == RT_ERROR_TIMEOUT )
       {

--- a/remote/rtRemoteEnvironment.cpp
+++ b/remote/rtRemoteEnvironment.cpp
@@ -168,7 +168,7 @@ rtRemoteEnvironment::waitForResponse(std::chrono::milliseconds timeout, rtRemote
 }
 
 rtError
-rtRemoteEnvironment::processSingleWorkItem(std::chrono::milliseconds timeout, bool wait, rtRemoteCorrelationKey* key)
+rtRemoteEnvironment::processSingleWorkItem(std::chrono::milliseconds timeout, bool wait, rtRemoteCorrelationKey* key, const rtRemoteCorrelationKey* const specificKey)
 {
   rtError e = RT_ERROR_TIMEOUT;
 
@@ -179,24 +179,27 @@ rtRemoteEnvironment::processSingleWorkItem(std::chrono::milliseconds timeout, bo
   auto delay = std::chrono::system_clock::now() + timeout;
 
   std::unique_lock<std::mutex> lock(m_queue_mutex);
-  if (!wait && m_queue.empty())
+  if (!wait && m_queue.empty() && m_specific_workitem_map.empty())
     return RT_ERROR_QUEUE_EMPTY;
 
-  //
-  // TODO: if someone is already waiting for a specifc response
-  // then we should use a 2nd queue
-  //
-
-  if (!m_queue_cond.wait_until(lock, delay, [this] { return !this->m_queue.empty() || !m_running; }))
+  if (!m_queue_cond.wait_until(lock, delay, [this] { return !this->m_queue.empty() || !this->m_specific_workitem_map.empty() || !m_running; }))
   {
     e = RT_ERROR_TIMEOUT;
   }
   else
   {
-    if (!m_running)
+    if (!m_running || (specificKey && m_response_handlers.find(*specificKey) == m_response_handlers.end()))
       return RT_OK;
 
-    if (!m_queue.empty())
+    WorkItemMap::iterator it;
+
+    if (specificKey && *specificKey != kInvalidCorrelationKey &&
+      (it = m_specific_workitem_map.find(*specificKey)) != m_specific_workitem_map.end())
+    {
+      workItem = it->second;
+      m_specific_workitem_map.erase(it);
+    }
+    else if (!m_queue.empty())
     {
       workItem = m_queue.front();
       m_queue.pop();
@@ -250,26 +253,23 @@ rtRemoteEnvironment::enqueueWorkItem(std::shared_ptr<rtRemoteClient> const& clnt
 
   std::unique_lock<std::mutex> lock(m_queue_mutex);
 
-  #if 0
-  // TODO if someone is waiting for this message, then deliver it directly
+
+  // If someone is waiting for this message, then store it to a specific map
+  // Otherwise, put it to a queue
   rtRemoteCorrelationKey const k = rtMessage_GetCorrelationKey(*workItem.Message);
   auto itr = m_response_handlers.find(k);
   if (itr != m_response_handlers.end())
   {
-    rtError e = itr->second.Func(workItem.Client, workItem.Message, itr->second.Arg);
-    if (e != RT_OK)
-      rtLogWarn("error dispatching message directly to waiter. %s", rtStrError(e));
+    m_specific_workitem_map.insert(WorkItemMap::value_type(k, workItem));
+    lock.unlock();
+    m_queue_cond.notify_all();
   }
   else
   {
     m_queue.push(workItem);
+    lock.unlock();
     m_queue_cond.notify_all();
   }
-  #endif
-
-  m_queue.push(workItem);
-  lock.unlock();
-  m_queue_cond.notify_all();
 
   if (m_queue_ready_handler != nullptr)
   {

--- a/remote/rtRemoteEnvironment.h
+++ b/remote/rtRemoteEnvironment.h
@@ -44,7 +44,7 @@ public:
   void registerResponseHandler(rtRemoteMessageHandler handler, void* argp, rtRemoteCorrelationKey const& k);
   void removeResponseHandler(rtRemoteCorrelationKey const& k);
   void enqueueWorkItem(std::shared_ptr<rtRemoteClient> const& clnt, rtRemoteMessagePtr const& doc);
-  rtError processSingleWorkItem(std::chrono::milliseconds timeout, bool wait, rtRemoteCorrelationKey* key);
+  rtError processSingleWorkItem(std::chrono::milliseconds timeout, bool wait, rtRemoteCorrelationKey* key, const rtRemoteCorrelationKey* const specificKey = nullptr);
   rtError waitForResponse(std::chrono::milliseconds timeout, rtRemoteCorrelationKey key);
 
 private:
@@ -62,6 +62,7 @@ private:
 
   using ResponseHandlerMap = std::map< rtRemoteCorrelationKey, rtRemoteCallback<rtRemoteMessageHandler> >;
   using ResponseMap = std::map< rtRemoteCorrelationKey, ResponseState >;
+  using WorkItemMap = std::map< rtRemoteCorrelationKey, WorkItem >;
 
   void processRunQueue();
 
@@ -80,6 +81,7 @@ private:
   bool                          m_running;
   ResponseHandlerMap            m_response_handlers;
   ResponseMap                   m_waiters;
+  WorkItemMap                   m_specific_workitem_map; // Store workitems for pending requests here, not m_queue
   rtRemoteQueueReady            m_queue_ready_handler;
   void*                         m_queue_ready_context;
 };


### PR DESCRIPTION
Instead of using the second queue, I added a map `m_specific_workitem_map` to store the workitems for the pending requests. Because `m_specific_workitem_map` is much easier than queue to get workItem by key.